### PR TITLE
Update/v0.13

### DIFF
--- a/mb_conan_build.cmake
+++ b/mb_conan_build.cmake
@@ -20,6 +20,7 @@ if( NOT CONAN_EXPORTED )
 endif()
 
 option( MB_SKIP_CONAN_INSTALL "Prevent CMake from calling conan install" OFF )
+option( MB_BUILD_MISSING_CONAN_PACKAGES "Build conan packages that have not prebuilt binaries on the server available" ON)
 
 # in conan local cache or user has already performed conan install command
 if( CONAN_EXPORTED OR MB_SKIP_CONAN_INSTALL )
@@ -55,7 +56,7 @@ else() # in user space and user has not performed conan install command
     # Download automatically, you can also just copy the conan.cmake file
     if( NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake" )
        message( STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan" )
-       file( DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.12/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake" )
+       file( DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/v0.13/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake" )
     endif()
     include( ${CMAKE_BINARY_DIR}/conan.cmake )
 
@@ -70,121 +71,137 @@ else() # in user space and user has not performed conan install command
 
     # workaround for https://github.com/conan-io/cmake-conan/issues/85
     macro( mb_conan_cmake_run )
-        parse_arguments( ${ARGV} )
-        if( ARGUMENTS_PROFILE )
-            # workaround (only for our specific use cases)
-            set(settings -pr ${ARGUMENTS_PROFILE})
-            conan_cmake_setup_conanfile(${ARGV})
-            set(CONAN_OPTIONS "")
-            if(ARGUMENTS_CONANFILE)
-                set(CONANFILE ${CMAKE_CURRENT_SOURCE_DIR}/${ARGUMENTS_CONANFILE})
-                # A conan file has been specified - apply specified options as well if provided
-                foreach(ARG ${ARGUMENTS_OPTIONS})
-                    set(CONAN_OPTIONS ${CONAN_OPTIONS} -o ${ARG})
-                endforeach()
-            else()
-                set(CONANFILE ".")
-            endif()
+        # parse_arguments( ${ARGV} )
+        # if( ARGUMENTS_PROFILE )
+        #     # workaround (only for our specific use cases)
+        #     set(settings -pr=${ARGUMENTS_PROFILE})
+        #     conan_cmake_setup_conanfile(${ARGV})
+        #     set(CONAN_OPTIONS "")
+        #     if(ARGUMENTS_CONANFILE)
+        #         set(CONANFILE ${CMAKE_CURRENT_SOURCE_DIR}/${ARGUMENTS_CONANFILE})
+        #     else()
+        #         set(CONANFILE ".")
+        #     endif()
 
-            set(CONAN_INSTALL_FOLDER "")
-            if(ARGUMENTS_INSTALL_FOLDER)
-                set(CONAN_INSTALL_FOLDER -if ${ARGUMENTS_INSTALL_FOLDER})
-            endif()
+        #     foreach(ARG ${ARGUMENTS_OPTIONS})
+        #         set(CONAN_OPTIONS ${CONAN_OPTIONS} -o=${ARG})
+        #     endforeach()
+        #     foreach(ARG ${ARGUMENTS_ENV})
+        #         set(CONAN_OPTIONS ${CONAN_OPTIONS} -e=${ARG})
+        #     endforeach()
 
-            # if dev-release, then use cmake generator, not cmake_multi
-            message( STATUS "CONAN_CMAKE_MULTI: ${CONAN_CMAKE_MULTI}, MB_DEV_RELEASE: ${MB_DEV_RELEASE}")
-            if(CONAN_CMAKE_MULTI AND NOT MB_DEV_RELEASE)
-                foreach(build_type "Release" "Debug")
-                    set( CONAN_INVOCATION conan install ${CONANFILE} ${settings} -g cmake_multi ${CONAN_OPTIONS} -s build_type=${build_type} --build=missing )
-                    string (REPLACE ";" " " _CONAN_INVOCATION "${CONAN_INVOCATION}")
-                    message( STATUS "Conan executing: ${_CONAN_INVOCATION}" )
-                    execute_process(
-                        COMMAND
-                            ${CONAN_INVOCATION}
-                        RESULT_VARIABLE
-                            return_code
-                        WORKING_DIRECTORY
-                            ${CMAKE_CURRENT_BINARY_DIR}
-                    )
-                    if( NOT "${return_code}" STREQUAL "0" )
-                        message(FATAL_ERROR "Conan install failed='${return_code}'")
-                    endif()
-                endforeach()
-            else()
-                set( invocation_build_type ${CMAKE_BUILD_TYPE} )
-                if( MB_DEV_RELEASE )
-                    set( invocation_build_type "Debug" )
-                endif()
-                set( CONAN_INVOCATION conan install ${CONANFILE} ${settings} -g cmake ${CONAN_OPTIONS} -s build_type=${invocation_build_type} --build=missing )
-                string (REPLACE ";" " " _CONAN_INVOCATION "${CONAN_INVOCATION}")
-                message( STATUS "Conan executing: ${_CONAN_INVOCATION}" )
-                execute_process(
-                    COMMAND
-                        ${CONAN_INVOCATION}
-                    RESULT_VARIABLE
-                        return_code
-                    WORKING_DIRECTORY
-                        ${CMAKE_CURRENT_BINARY_DIR}
-                )
-                if( NOT "${return_code}" STREQUAL "0" )
-                    message(FATAL_ERROR "Conan install failed='${return_code}'")
-                endif()
-            endif()
+        #     set(CONAN_INSTALL_FOLDER "")
+        #     if(ARGUMENTS_INSTALL_FOLDER)
+        #         set(CONAN_INSTALL_FOLDER -if=${ARGUMENTS_INSTALL_FOLDER})
+        #     endif()
 
-            # if dev-release, trick conan_load_buildinfo into thinking that we do not have cmake_multi generator so
-            # it will load correct cmakebuildinfo.cmake
-            if( MB_DEV_RELEASE )
-                set( CONAN_CMAKE_MULTI OFF )
-            endif()
-            conan_load_buildinfo()
+        #     if ( MB_BUILD_MISSING_CONAN_PACKAGES )
+        #         set(CONAN_OPTIONS ${CONAN_OPTIONS} --build=missing)
+        #     endif()
 
-            if(ARGUMENTS_BASIC_SETUP)
-                foreach(_option CMAKE_TARGETS KEEP_RPATHS NO_OUTPUT_DIRS)
-                    if(ARGUMENTS_${_option})
-                        if(${_option} STREQUAL "CMAKE_TARGETS")
-                            list(APPEND _setup_options "TARGETS")
-                        else()
-                            list(APPEND _setup_options ${_option})
-                        endif()
-                    endif()
-                endforeach()
-                conan_basic_setup(${_setup_options})
-            endif()
-        else()
-            if( CONAN_CMAKE_MULTI AND ARGUMENTS_BUILD_TYPE )
-                # if ARGUMENTS_BUILD_TYPE is set, we want given build type for all configurations, so we must
-                # trick conan_cmake_run into thinking that cmake is not run under multi-config generator
-                set( BACKUP_CMAKE_CONFIGURATION_TYPES ${CMAKE_CONFIGURATION_TYPES} )
-                set( CMAKE_CONFIGURATION_TYPES "" )
-                set( CMAKE_BUILD_TYPE ${ARGUMENTS_BUILD_TYPE} )
-            endif()
+        #     # if dev-release, then use cmake generator, not cmake_multi
+        #     message( STATUS "CONAN_CMAKE_MULTI: ${CONAN_CMAKE_MULTI}, MB_DEV_RELEASE: ${MB_DEV_RELEASE}")
+        #     if(CONAN_CMAKE_MULTI AND NOT MB_DEV_RELEASE)
+        #         foreach(build_type "Release" "Debug")
+        #             set( CONAN_INVOCATION conan install ${CONANFILE} ${settings} -g=cmake_multi -s=build_type=${build_type} ${CONAN_OPTIONS} )
+        #             string (REPLACE ";" " " _CONAN_INVOCATION "${CONAN_INVOCATION}")
+        #             message( STATUS "Conan executing: ${_CONAN_INVOCATION}" )
+        #             execute_process(
+        #                 COMMAND
+        #                     ${CONAN_INVOCATION}
+        #                 RESULT_VARIABLE
+        #                     return_code
+        #                 WORKING_DIRECTORY
+        #                     ${CMAKE_CURRENT_BINARY_DIR}
+        #             )
+        #             if( NOT "${return_code}" STREQUAL "0" )
+        #                 message(FATAL_ERROR "Conan install failed='${return_code}'")
+        #             endif()
+        #         endforeach()
+        #     else()
+        #         set( invocation_build_type ${CMAKE_BUILD_TYPE} )
+        #         if( MB_DEV_RELEASE )
+        #             set( invocation_build_type "Debug" )
+        #         endif()
+        #         set( CONAN_INVOCATION conan install ${CONANFILE} ${settings} -g cmake -s build_type=${invocation_build_type} ${CONAN_OPTIONS} )
+        #         string (REPLACE ";" " " _CONAN_INVOCATION "${CONAN_INVOCATION}")
+        #         message( STATUS "Conan executing: ${_CONAN_INVOCATION}" )
+        #         execute_process(
+        #             COMMAND
+        #                 ${CONAN_INVOCATION}
+        #             RESULT_VARIABLE
+        #                 return_code
+        #             WORKING_DIRECTORY
+        #                 ${CMAKE_CURRENT_BINARY_DIR}
+        #         )
+        #         if( NOT "${return_code}" STREQUAL "0" )
+        #             message(FATAL_ERROR "Conan install failed='${return_code}'")
+        #         endif()
+        #     endif()
+
+        #     # if dev-release, trick conan_load_buildinfo into thinking that we do not have cmake_multi generator so
+        #     # it will load correct cmakebuildinfo.cmake
+        #     if( MB_DEV_RELEASE )
+        #         set( CONAN_CMAKE_MULTI OFF )
+        #     endif()
+        #     conan_load_buildinfo()
+
+        #     if(ARGUMENTS_BASIC_SETUP)
+        #         foreach(_option CMAKE_TARGETS KEEP_RPATHS NO_OUTPUT_DIRS)
+        #             if(ARGUMENTS_${_option})
+        #                 if(${_option} STREQUAL "CMAKE_TARGETS")
+        #                     list(APPEND _setup_options "TARGETS")
+        #                 else()
+        #                     list(APPEND _setup_options ${_option})
+        #                 endif()
+        #             endif()
+        #         endforeach()
+        #         conan_basic_setup(${_setup_options})
+        #     endif()
+        # else()
+            # if( CONAN_CMAKE_MULTI AND ARGUMENTS_BUILD_TYPE )
+            #     # if ARGUMENTS_BUILD_TYPE is set, we want given build type for all configurations, so we must
+            #     # trick conan_cmake_run into thinking that cmake is not run under multi-config generator
+            #     set( BACKUP_CMAKE_CONFIGURATION_TYPES ${CMAKE_CONFIGURATION_TYPES} )
+            #     set( CMAKE_CONFIGURATION_TYPES "" )
+            #     set( CMAKE_BUILD_TYPE ${ARGUMENTS_BUILD_TYPE} )
+            # endif()
 
             # call default implementation
             conan_cmake_run( ${ARGV} )
 
             # restore cmake configuration types from backup (if any)
-            if( BACKUP_CMAKE_CONFIGURATION_TYPES )
-                set( CMAKE_CONFIGURATION_TYPES ${BACKUP_CMAKE_CONFIGURATION_TYPES} )
-                set( CMAKE_BUILD_TYPE "" )
-            endif()
-        endif()
+            # if( BACKUP_CMAKE_CONFIGURATION_TYPES )
+            #     set( CMAKE_CONFIGURATION_TYPES ${BACKUP_CMAKE_CONFIGURATION_TYPES} )
+            #     set( CMAKE_BUILD_TYPE "" )
+            # endif()
+        # endif()
     endmacro()
 
     # detect profile
+    set( HAVE_PROFILE OFF )
     if( IOS )
         list( APPEND conan_cmake_run_params PROFILE ios )
+        set( HAVE_PROFILE ON )
     elseif( ANDROID )
         list( APPEND conan_cmake_run_params PROFILE android-${ANDROID_ABI} )
+        set( HAVE_PROFILE ON )
     elseif( CMAKE_SYSTEM_NAME STREQUAL "Linux" )
         if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
             list( APPEND conan_cmake_run_params PROFILE clang )
         else()
             list( APPEND conan_cmake_run_params PROFILE gcc )
         endif()
+        set( HAVE_PROFILE ON )
     endif()
 
     if( MB_CONAN_SETUP_PARAMS )
         list( APPEND conan_cmake_run_params ${MB_CONAN_SETUP_PARAMS} )
+    endif()
+
+    if ( HAVE_PROFILE )
+        # use automatically detected build type when using profile
+        list( APPEND conan_cmake_run_params PROFILE_AUTO build_type )
     endif()
 
     # other cases should be auto-detected by conan.cmake

--- a/mb_conan_build.cmake
+++ b/mb_conan_build.cmake
@@ -69,6 +69,10 @@ else() # in user space and user has not performed conan install command
         list( APPEND conan_cmake_run_params BUILD_TYPE "Debug" )
     endif()
 
+    if ( MB_DEV_RELEASE AND CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT CMAKE_BUILD_TYPE )
+        set( CMAKE_BUILD_TYPE Debug ) # required to correctly detect VS runtime toolset
+    endif()
+
     # detect profile
     set( HAVE_PROFILE OFF )
     if( IOS )


### PR DESCRIPTION
- update upstream conan.cmake to v0.13 and remove workarounds for bugs that have now been fixed
- provide option `MB_BUILD_MISSING_CONAN_PACKAGES` (`ON` by default) that can disable building of missing conan packages